### PR TITLE
Open app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # search joplin notes Changelog
 
+## [FIX Codes] - 2024-11-29
+
+Fix "Open Note" action to use redirect_url
+
 ## [FIX Codes] - 2024-9-21
 
 Modify it so that the search results can be changed in the settings

--- a/raycast-env.d.ts
+++ b/raycast-env.d.ts
@@ -11,7 +11,7 @@ type ExtensionPreferences = {
   /** Joplin Auth Token - You can get this token from the Joplin desktop application, on the Web Clipper Options screen. */
   "joplin_token": string,
   /** Search Display Limit - The number of notes to display in the search results. Default is 9. */
-  "search_limit": "3" | "6" | "9" | "12"
+  "search_limit": "6" | "9" | "12" | "18"
 }
 
 /** Preferences accessible in all the extension's commands */

--- a/src/components/NoteDetail.tsx
+++ b/src/components/NoteDetail.tsx
@@ -14,7 +14,7 @@ export const NoteDetail = (props: Props) => {
       isLoading={isLoading}
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser url={url} />
+          <Action.OpenInBrowser url={url} title="Open note" />
         </ActionPanel>
       }
     />

--- a/src/components/NoteDetail.tsx
+++ b/src/components/NoteDetail.tsx
@@ -6,7 +6,7 @@ type Props = { id: string };
 export const NoteDetail = (props: Props) => {
   const { id } = props;
   const { isLoading, data } = useNoteDetailFetch(id);
-  const url = `joplin://x-callback-url/openNote?id=${id}` 
+  const url = `joplin://x-callback-url/openNote?id=${id}`;
 
   return (
     <Detail

--- a/src/components/NoteDetail.tsx
+++ b/src/components/NoteDetail.tsx
@@ -1,13 +1,12 @@
 import { Detail, Action, ActionPanel } from "@raycast/api";
-import { useCachedState } from "@raycast/utils";
 import { useNoteDetailFetch } from "./../utils/hooks";
 
 type Props = { id: string };
 
 export const NoteDetail = (props: Props) => {
   const { id } = props;
-  const [{ path }] = useCachedState("path", { cached: false, path: "/Applications/Joplin.app" });
   const { isLoading, data } = useNoteDetailFetch(id);
+  const url = `joplin://x-callback-url/openNote?id=${id}` 
 
   return (
     <Detail
@@ -15,7 +14,7 @@ export const NoteDetail = (props: Props) => {
       isLoading={isLoading}
       actions={
         <ActionPanel>
-          <Action.Open title="Open Note" target={path} />
+          <Action.OpenInBrowser url={url} />
         </ActionPanel>
       }
     />


### PR DESCRIPTION
Modify the "open note" action.

Update it to use the `redirect_url` provided by Joplin so that the target note opens directly in the app.

To utilize the `redirect_url`, a temporary redirection to the browser is required.